### PR TITLE
Add player argument and WarpSpawn command

### DIFF
--- a/src/main/java/net/cubespace/geSuiteSpawn/commands/GlobalSpawnCommand.java
+++ b/src/main/java/net/cubespace/geSuiteSpawn/commands/GlobalSpawnCommand.java
@@ -17,7 +17,41 @@ public class GlobalSpawnCommand implements CommandExecutor {
 	public boolean onCommand(CommandSender sender, Command command,
 			String label, String[] args) {
 
-		final Player player = Bukkit.getPlayer(sender.getName());
+            /* Console Commands */
+            if ( !( sender instanceof Player ) ) {
+                if (args.length != 1) {
+                    return false;
+                }
+
+                Player player = Bukkit.getPlayer(args[0]);
+                if (player == null) {
+                    sender.sendMessage(ChatColor.RED + "Invalid username or player is offline.");
+                    return true;
+                }
+
+                SpawnManager.sendPlayerToProxySpawn(player, false);
+                return true;
+            }
+
+            /* Player Commands */
+            final Player player = (Player) sender;
+            
+            if (args.length == 1) {
+                if (!player.hasPermission("gesuit.warps.command.warp.other")) {
+                    player.sendMessage(ChatColor.RED + "You do not have permission to do this.");
+                    return true;
+                }
+
+                Player target = Bukkit.getPlayer(args[0]);
+                if (target == null) {
+                    player.sendMessage(ChatColor.RED + "Invalid username or player is offline.");
+                    return true;
+                }
+
+                SpawnManager.sendPlayerToProxySpawn(target, false);
+                return true;
+            }
+
         if (!player.hasPermission("gesuit.warps.bypass.delay")) {
             final Location lastLocation = player.getLocation();
 

--- a/src/main/java/net/cubespace/geSuiteSpawn/commands/ServerSpawnCommand.java
+++ b/src/main/java/net/cubespace/geSuiteSpawn/commands/ServerSpawnCommand.java
@@ -18,7 +18,41 @@ public class ServerSpawnCommand implements CommandExecutor {
 	public boolean onCommand(CommandSender sender, Command command,
 			String label, String[] args) {
 
-        final Player player = Bukkit.getPlayer(sender.getName());
+            /* Console Commands */
+            if ( !( sender instanceof Player ) ) {
+                if (args.length != 1) {
+                    return false;
+                }
+
+                Player player = Bukkit.getPlayer(args[0]);
+                if (player == null) {
+                    sender.sendMessage(ChatColor.RED + "Invalid username or player is offline.");
+                    return true;
+                }
+
+                SpawnManager.sendPlayerToServerSpawn(player);
+                return true;
+            }
+
+            /* Player Commands */
+            final Player player = (Player) sender;
+
+            if (args.length == 1) {
+                if (!player.hasPermission("gesuit.warps.command.warp.other")) {
+                    player.sendMessage(ChatColor.RED + "You do not have permission to do this.");
+                    return true;
+                }
+
+                Player target = Bukkit.getPlayer(args[0]);
+                if (target == null) {
+                    player.sendMessage(ChatColor.RED + "Invalid username or player is offline.");
+                    return true;
+                }
+
+                SpawnManager.sendPlayerToServerSpawn(target);
+                return true;
+            }
+
         if (!player.hasPermission("gesuit.warps.bypass.delay")) {
             final Location lastLocation = player.getLocation();
 

--- a/src/main/java/net/cubespace/geSuiteSpawn/commands/SpawnCommand.java
+++ b/src/main/java/net/cubespace/geSuiteSpawn/commands/SpawnCommand.java
@@ -17,7 +17,41 @@ public class SpawnCommand implements CommandExecutor {
 	public boolean onCommand(CommandSender sender, Command command,
 			String label, String[] args) {
 
-		final Player player = Bukkit.getPlayer(sender.getName());
+            /* Console Commands */
+            if ( !( sender instanceof Player ) ) {
+                if (args.length != 1) {
+                    return false;
+                }
+
+                Player player = Bukkit.getPlayer(args[0]);
+                if (player == null) {
+                    sender.sendMessage(ChatColor.RED + "Invalid username or player is offline.");
+                    return true;
+                }
+
+                SpawnManager.sendPlayerToSpawn(player);
+                return true;
+            }
+
+            /* Player Commands */
+            final Player player = (Player) sender;
+
+            if (args.length == 1) {
+                if (!player.hasPermission("gesuit.warps.command.warp.other")) {
+                    player.sendMessage(ChatColor.RED + "You do not have permission to do this.");
+                    return true;
+                }
+
+                Player target = Bukkit.getPlayer(args[0]);
+                if (target == null) {
+                    player.sendMessage(ChatColor.RED + "Invalid username or player is offline.");
+                    return true;
+                }
+
+                SpawnManager.sendPlayerToSpawn(target);
+                return true;
+            }
+
         if (!player.hasPermission("gesuit.warps.bypass.delay")) {
             final Location lastLocation = player.getLocation();
 

--- a/src/main/java/net/cubespace/geSuiteSpawn/commands/WarpSpawnCommand.java
+++ b/src/main/java/net/cubespace/geSuiteSpawn/commands/WarpSpawnCommand.java
@@ -1,0 +1,119 @@
+package net.cubespace.geSuiteSpawn.commands;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import net.cubespace.geSuiteSpawn.geSuitSpawn;
+import net.cubespace.geSuiteSpawn.managers.SpawnManager;
+
+public class WarpSpawnCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+
+        /* Console Commands */
+        if ( !( sender instanceof Player ) ) {
+            if (args.length == 0 || args.length == 1) {
+                return false;
+            }
+
+            Player player = Bukkit.getPlayer(args[0]);
+            if (player == null) {
+                sender.sendMessage(ChatColor.RED + "Invalid username or player is offline.");
+                return true;
+            }
+
+            // warpspawn SpawnName
+            if (args.length == 2) {
+                SpawnManager.sendPlayerToArgSpawn(player, args[1], "");
+                return true;
+            }
+
+            // warpspawn SpawnName Server
+            if (args.length == 3) {
+                SpawnManager.sendPlayerToArgSpawn(player, args[1], args[2]);
+                return true;
+            }
+
+            return false;
+        }
+
+        /* Player Commands */
+        final Player player = (Player) sender;
+
+        if (args.length == 0) {
+            return false;
+        }
+
+        // warpspawn SpawnName
+        if (args.length == 1) {
+            sendToSpawn(player, args[0], "");
+            return true;
+        }
+
+        // warpspawn (Player) SpawnName Server
+        if (args.length == 2) {
+            Player target = Bukkit.getPlayer(args[0]);
+            if (target != null) {
+                if (!player.hasPermission("gesuit.warps.command.warp.other")) {
+                    player.sendMessage(ChatColor.RED + "You do not have permission to do this.");
+                    return true;
+                }
+                SpawnManager.sendPlayerToArgSpawn(target, args[1], "");
+                return true;
+            }
+            sendToSpawn(player, args[0], args[1]);
+            return true;
+        }
+
+        // warpspawn Player SpawnName Server
+        if (args.length == 3) {
+            if (!player.hasPermission("gesuit.warps.command.warp.other")) {
+                player.sendMessage(ChatColor.RED + "You do not have permission to do this.");
+                return true;
+            }
+
+            Player target = Bukkit.getPlayer(args[0]);
+            if (target == null) {
+                player.sendMessage(ChatColor.RED + "Invalid username or player is offline.");
+                return true;
+            }
+
+            SpawnManager.sendPlayerToArgSpawn(target, args[1], args[2]);
+            return true;
+        }
+
+        return false;
+    }
+
+    private void sendToSpawn(final Player player, final String spawn, final String server) {
+        if (!player.hasPermission("gesuit.warps.bypass.delay")) {
+            final Location lastLocation = player.getLocation();
+            player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&6Teleportation will commence in &c3 seconds&6. Don't move."));
+            Bukkit.getServer().getScheduler().runTaskLater(geSuitSpawn.INSTANCE, new Runnable() {
+                @Override
+                public void run() {
+                    if (player.isOnline()) {
+                        if ((lastLocation == null) || (lastLocation.getBlock() == null))
+                            return;
+
+                        if (lastLocation.getBlock().equals(player.getLocation().getBlock())) {
+                            player.sendMessage(ChatColor.GOLD + "Teleportation commencing...");
+                            SpawnManager.sendPlayerToArgSpawn(player, spawn, server);
+                        } else {
+                            player.sendMessage(ChatColor.RED + "Teleportation aborted because you moved.");
+                        }
+                    }
+                }
+            }, 60L);
+        } else {
+            SpawnManager.sendPlayerToArgSpawn(player, spawn, server);
+        }
+    }
+
+}

--- a/src/main/java/net/cubespace/geSuiteSpawn/commands/WorldSpawnCommand.java
+++ b/src/main/java/net/cubespace/geSuiteSpawn/commands/WorldSpawnCommand.java
@@ -17,7 +17,41 @@ public class WorldSpawnCommand implements CommandExecutor {
 	public boolean onCommand(CommandSender sender, Command command,
 			String label, String[] args) {
 
-		final Player player = Bukkit.getPlayer(sender.getName());
+            /* Console Commands */
+            if ( !( sender instanceof Player ) ) {
+                if (args.length != 1) {
+                    return false;
+                }
+
+                Player player = Bukkit.getPlayer(args[0]);
+                if (player == null) {
+                    sender.sendMessage(ChatColor.RED + "Invalid username or player is offline.");
+                    return true;
+                }
+
+                SpawnManager.sendPlayerToWorldSpawn(player);
+                return true;
+            }
+
+            /* Player Commands */
+            final Player player = (Player) sender;
+
+            if (args.length == 1) {
+                if (!player.hasPermission("gesuit.warps.command.warp.other")) {
+                    player.sendMessage(ChatColor.RED + "You do not have permission to do this.");
+                    return true;
+                }
+
+                Player target = Bukkit.getPlayer(args[0]);
+                if (target == null) {
+                    player.sendMessage(ChatColor.RED + "Invalid username or player is offline.");
+                    return true;
+                }
+
+                SpawnManager.sendPlayerToWorldSpawn(target);
+                return true;
+            }
+
         if (!player.hasPermission("gesuit.warps.bypass.delay")) {
             final Location lastLocation = player.getLocation();
 

--- a/src/main/java/net/cubespace/geSuiteSpawn/geSuitSpawn.java
+++ b/src/main/java/net/cubespace/geSuiteSpawn/geSuitSpawn.java
@@ -8,6 +8,7 @@ import net.cubespace.geSuiteSpawn.commands.SetServerSpawnCommand;
 import net.cubespace.geSuiteSpawn.commands.SetWorldSpawnCommand;
 import net.cubespace.geSuiteSpawn.commands.DelWorldSpawnCommand;
 import net.cubespace.geSuiteSpawn.commands.SpawnCommand;
+import net.cubespace.geSuiteSpawn.commands.WarpSpawnCommand;
 import net.cubespace.geSuiteSpawn.commands.WorldSpawnCommand;
 import net.cubespace.geSuiteSpawn.listeners.SpawnListener;
 import net.cubespace.geSuiteSpawn.listeners.SpawnMessageListener;
@@ -36,6 +37,7 @@ public class geSuitSpawn extends JavaPlugin {
 		getCommand("worldspawn").setExecutor(new WorldSpawnCommand());
 		getCommand("serverspawn").setExecutor(new ServerSpawnCommand());
 		getCommand("globalspawn").setExecutor(new GlobalSpawnCommand());
+                getCommand("warpspawn").setExecutor(new WarpSpawnCommand());
 	}
 
 	private void registerChannels() {

--- a/src/main/java/net/cubespace/geSuiteSpawn/managers/SpawnManager.java
+++ b/src/main/java/net/cubespace/geSuiteSpawn/managers/SpawnManager.java
@@ -209,6 +209,21 @@ public class SpawnManager {
 
     }
 
+    public static void sendPlayerToArgSpawn( CommandSender sender, String spawn, String server ) {
+        ByteArrayOutputStream b = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream( b );
+        try {
+            out.writeUTF( "SendToArgSpawn" );
+            out.writeUTF( sender.getName() );
+            out.writeUTF( spawn );
+            out.writeUTF( server );
+
+        } catch ( IOException e ) {
+            e.printStackTrace();
+        }
+        new PluginMessageTask( b ).runTaskAsynchronously( geSuitSpawn.INSTANCE );
+    }
+
     public static void sendVersion() {
         ByteArrayOutputStream b = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream( b );

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -57,6 +57,11 @@ commands:
         aliases: [gs,hub,lobby]
         permission-message: §cYou do not have permission for this command
         usage: /<command> (player)
+    warpspawn:
+        description: Sends the player to a specified spawn
+        permission: gesuit.spawns.command.warpspawn
+        permission-message: §cYou do not have permission for this command
+        usage: /<command> (player) (spawnName) (serverName)
 
 permissions:
     gesuit.spawns.*:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,44 +10,53 @@ commands:
         permission: gesuit.spawns.command.setnewspawn
         aliases: [sns, setnewplayerspawn, setnoobspawn]
         permission-message: §cYou do not have permission for this command
+        usage: /<command>
     setworldspawn:
         description: Sets the proxies world spawn point.
         permission: gesuit.spawns.command.setworldspawn
         aliases: [sws]
         permission-message: §cYou do not have permission for this command
+        usage: /<command>
     delworldspawn:
         description: Deletes the proxies world spawn point.
         permission: gesuit.spawns.command.delworldspawn
         permission-message: §cYou do not have permission for this command
+        usage: /<command>
     setserverspawn:
         description: Sets the servers spawn point.
         permission: gesuit.spawns.command.setserverspawn
         aliases: [sss]
         permission-message: §cYou do not have permission for this command
+        usage: /<command>
     setglobalspawn:
         description: Sets the proxies global spawn point.
         permission: gesuit.spawns.command.setglobalspawn
         aliases: [sgs, setproxyspawn,sethub,sethubspawn]
         permission-message: §cYou do not have permission for this command
+        usage: /<command>
     spawn:
         description: Sends the player to the relevent spawn
         permission: gesuit.spawns.command.spawn
         permission-message: §cYou do not have permission for this command
+        usage: /<command> (player)
     worldspawn:
         description: Sends the player to the worlds spawn
         permission: gesuit.spawns.command.worldspawn
         aliases: [ws]
         permission-message: §cYou do not have permission for this command
+        usage: /<command> (player)
     serverspawn:
         description: Sends the player to the servers spawn
         permission: gesuit.spawns.command.serverspawn
         aliases: [ss]
         permission-message: §cYou do not have permission for this command
+        usage: /<command> (player)
     globalspawn:
         description: Sends the player to the proxys spawn
         permission: gesuit.spawns.command.globalspawn
         aliases: [gs,hub,lobby]
         permission-message: §cYou do not have permission for this command
+        usage: /<command> (player)
 
 permissions:
     gesuit.spawns.*:


### PR DESCRIPTION
Add player argument to spawn commands. /spawn (player)
Requires the permission 'gesuit.warps.command.warp.other'.
Add the ability to send a player to spawn from console.

Add WarpSpawn command. This allows you to warp to any servers spawn point in the spawns database. /warpspawn (player) [SpawnName] [ServerName]
Example Uses:
/warpspawn server Lobby - Warp to the server spawn of the Lobby server.
/warpspawn Factions - Warp to world spawn of Factions.
/warpspawn NewPlayerSpawn - Warp to spawn point for new players.
